### PR TITLE
Fix ⊗₁

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
-desc = "Rounding without rounding modes, using error-free transformations."
-keywords = ["round", "directed rounding", "error-free transformations", "floating-point"]
 name = "FastRounding"
-author = "Jeffrey Sarnoff"
 uuid = "fa42c844-2597-5d31-933b-ebd51ab2693f"
-version = "v0.3.0"
+keywords = ["round", "directed rounding", "error-free transformations", "floating-point"]
+desc = "Rounding without rounding modes, using error-free transformations."
+author = "Jeffrey Sarnoff"
+version = "0.3.0"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ErrorfreeArithmetic = "90fa49ef-747e-5e6f-a989-263ba693cf1a"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 ErrorfreeArithmetic = ">=0.2.0"

--- a/src/FastRounding.jl
+++ b/src/FastRounding.jl
@@ -94,7 +94,7 @@ mul_round(a::T, b::T) where {T<:SysFloat} = a * b
 ⊗₊(a::T, b::T) where {T<:SysFloat} = mul_round(a, b, RoundUp)
 ⊗₋(a::T, b::T) where {T<:SysFloat} = mul_round(a, b, RoundDown)
 ⊗₀(a::T, b::T) where {T<:SysFloat} = mul_round(a, b, RoundToZero)
-⊗₁(a::T, b::T) where {T<:SysFloat} = inv_round(a, b, RoundFromZero)
+⊗₁(a::T, b::T) where {T<:SysFloat} = mul_round(a, b, RoundFromZero)
 
 @inline function inv_round(a::T, rounding::R)::T where {T<:SysFloat, R<:RoundingMode}
     hi, lo = two_inv(a)


### PR DESCRIPTION
Hi,

Currently ⊗₁ uses `inv_round` but I think this is a typo of`mul_round`.
```julia
julia> using FastRounding

julia> ⊗₌(0.2, 0.4)
0.08000000000000002

julia> ⊗₁(0.2, 0.4)
ERROR: MethodError: no method matching inv_round(::Float64, ::Float64, ::RoundingMode{:FromZero})
Closest candidates are:
  inv_round(::T) where T<:Union{Float32, Float64} at /Users/matsueushi/Documents/FastRounding.jl/src/FastRounding.jl:108
  inv_round(::T, ::R) where {T<:Union{Float32, Float64}, R<:RoundingMode} at /Users/matsueushi/Documents/FastRounding.jl/src/FastRounding.jl:100
Stacktrace:
 [1] ⊗₁(::Float64, ::Float64) at /Users/matsueushi/Documents/FastRounding.jl/src/FastRounding.jl:97
 [2] top-level scope at REPL[14]:1
```